### PR TITLE
fix: exclude e2e tests from default rake spec task [SPI-1278]

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -357,7 +357,8 @@ bundle exec rake spec      # Runs unit tests (explicit)
 
 # Test variants
 bundle exec rake spec:integration  # Integration tests only
-bundle exec rake spec:all          # All tests (unit + integration)
+bundle exec rake spec:e2e          # E2E tests only (requires OrbStack)
+bundle exec rake spec:all          # All tests (unit + integration + e2e)
 
 # Build and package
 bundle exec rake build     # Build gem to pkg/ directory
@@ -369,9 +370,10 @@ bundle exec rake release   # Build, tag, and push to RubyGems
 ```
 
 **Task Descriptions:**
-- **spec**: Runs unit tests (excludes integration tests to prevent recursion)
+- **spec**: Runs unit tests (excludes integration and e2e tests for fast feedback)
 - **spec:integration**: Runs integration tests for Rakefile tasks
-- **spec:all**: Runs complete test suite (unit + integration)
+- **spec:e2e**: Runs end-to-end tests (requires OrbStack and Vagrant installed)
+- **spec:all**: Runs complete test suite (unit + integration + e2e)
 - **build**: Creates `.gem` file in `pkg/` directory
 - **install**: Builds and installs gem to local gem repository
 - **clean**: Removes `pkg/` directory and build artifacts

--- a/Rakefile
+++ b/Rakefile
@@ -5,10 +5,11 @@ require 'rspec/core/rake_task'
 require 'fileutils'
 require 'io/console'
 
-# Define RSpec task - exclude integration tests to prevent recursion
+# Define RSpec task - exclude integration and e2e tests
+# E2E tests require real Vagrant and OrbStack and are run separately
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/**/*_spec.rb'
-  t.exclude_pattern = 'spec/integration/**/*_spec.rb'
+  t.exclude_pattern = 'spec/{integration,e2e}/**/*_spec.rb'
   t.rspec_opts = '--format documentation'
 end
 
@@ -18,7 +19,13 @@ RSpec::Core::RakeTask.new('spec:integration') do |t|
   t.rspec_opts = '--format documentation'
 end
 
-# All tests (unit + integration)
+# E2E tests (real Vagrant execution - requires Vagrant and OrbStack)
+RSpec::Core::RakeTask.new('spec:e2e') do |t|
+  t.pattern = 'spec/e2e/**/*_spec.rb'
+  t.rspec_opts = '--format documentation'
+end
+
+# All tests (unit + integration + e2e)
 RSpec::Core::RakeTask.new('spec:all') do |t|
   t.pattern = 'spec/**/*_spec.rb'
   t.rspec_opts = '--format documentation'


### PR DESCRIPTION
## Summary

Fixed test suite failures by properly excluding E2E tests from the default `rake spec` task. E2E tests execute real Vagrant commands and should only run explicitly or in CI.

## Changes

- **Rakefile**: Exclude `spec/e2e/**/*_spec.rb` from default `rake spec` task
- **Rakefile**: Add dedicated `rake spec:e2e` task for running E2E tests explicitly
- **DEVELOPMENT.md**: Document new `spec:e2e` task and update task descriptions

## Before/After

**Before:**
- `rake spec` included E2E tests → hanging, 11 failures
- 527 unit tests + 11 e2e tests (requiring OrbStack)

**After:**  
- `rake spec` runs unit tests only → completes in <1s, 0 failures
- 527 unit tests, 0 failures
- E2E tests available via `rake spec:e2e`

## Test Results

```
$ bundle exec rake spec
Finished in 0.16691 seconds
527 examples, 0 failures, 5 pending
```

## Code Review

Reviewed and approved by code-reviewer agent:
- ✅ Correctness: Exclude pattern works correctly
- ✅ Consistency: New task matches existing patterns
- ✅ Best Practices: Follows Ruby/Rake conventions
- ✅ Documentation: DEVELOPMENT.md updated

## Related Issue

- Resolves [SPI-1278](https://linear.app/spiral-house/issue/SPI-1278)

🤖 Generated with [Claude Code](https://claude.com/claude-code)