### PR TITLE
docs: update README for RubyGems publication [SPI-1291]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A Vagrant provider plugin that enables [OrbStack](https://orbstack.dev/) as a backend for managing Linux development environments on macOS.
 
-![Development Status](https://img.shields.io/badge/status-alpha-orange)
-![Version](https://img.shields.io/badge/version-0.1.0-blue)
+[![Gem Version](https://badge.fury.io/rb/vagrant-orbstack.svg)](https://badge.fury.io/rb/vagrant-orbstack)
+[![Build Status](https://github.com/spiralhouse/vagrant-orbstack-provider/workflows/CI/badge.svg)](https://github.com/spiralhouse/vagrant-orbstack-provider/actions)
 [![codecov](https://codecov.io/gh/spiralhouse/vagrant-orbstack-provider/graph/badge.svg?token=VIHOdRkRJ9)](https://codecov.io/gh/spiralhouse/vagrant-orbstack-provider)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
@@ -18,6 +18,21 @@ OrbStack is a high-performance alternative to traditional VM solutions on macOS,
 This provider allows you to leverage OrbStack's performance while maintaining the familiar Vagrant workflow.
 
 > **Development Status**: This provider is under active development. Most features are not yet implemented. See [Project Status](#project-status) for details.
+
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Known Limitations](#known-limitations)
+- [Project Status](#project-status)
+- [Development](#development)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Support](#support)
+- [License](#license)
 
 ## Requirements
 
@@ -36,21 +51,10 @@ OrbStack must be installed and running on your system:
 
 ## Installation
 
-Since the plugin is not yet published to RubyGems, you'll need to build and install it locally:
+Install the plugin directly from RubyGems:
 
 ```bash
-# Clone the repository
-git clone https://github.com/johnburbridge/vagrant-orbstack-provider.git
-cd vagrant-orbstack-provider
-
-# Install dependencies
-bundle install
-
-# Build the gem
-gem build vagrant-orbstack.gemspec
-
-# Install the plugin locally
-vagrant plugin install pkg/vagrant-orbstack-0.1.0.gem
+vagrant plugin install vagrant-orbstack
 ```
 
 Verify the installation:
@@ -426,6 +430,19 @@ The provider supports the following Linux distributions available in OrbStack:
 
 **Note**: Distribution availability depends on your OrbStack installation. Refer to the [OrbStack documentation](https://docs.orbstack.dev/machines/) for the most current list of supported distributions and versions.
 
+## Known Limitations
+
+The following features are not yet supported in v0.1.0:
+
+- **Box Support**: Box format is not implemented. You must use distribution-based creation with `distro` and `version` configuration.
+- **Synced Folders**: Shared folders between host and guest are not yet supported.
+- **Networking**: Configuration is limited to OrbStack defaults. Custom network settings are not available.
+- **Command Execution**: The `vagrant ssh -c "command"` syntax is not yet supported. Use the workaround documented in the [SSH section](#ssh-access).
+- **Provisioners**: While basic provisioner support exists, not all scenarios have been tested.
+- **Platform**: macOS-only due to OrbStack platform requirement.
+
+These features are planned for future releases. See [CHANGELOG.md](./CHANGELOG.md) for version history and the [PRD](./docs/PRD.md) for the complete roadmap.
+
 ## Project Status
 
 ### Implemented
@@ -493,7 +510,7 @@ For complete roadmap, see [`docs/PRD.md`](./docs/PRD.md).
 
 ```bash
 # Clone and setup
-git clone https://github.com/johnburbridge/vagrant-orbstack-provider.git
+git clone https://github.com/spiralhouse/vagrant-orbstack-provider.git
 cd vagrant-orbstack-provider
 bundle install
 ```
@@ -526,6 +543,8 @@ yard doc
 
 ### Local Testing
 
+To test local changes before contributing:
+
 ```bash
 # Build and install gem locally
 gem build vagrant-orbstack.gemspec
@@ -542,8 +561,11 @@ Vagrant.configure("2") do |config|
 end
 EOF
 
-# Test (note: most features are stubs currently)
+# Test your changes
 vagrant up --provider=orbstack
+vagrant ssh
+vagrant halt
+vagrant destroy
 ```
 
 ## Documentation
@@ -578,8 +600,8 @@ This project follows Test-Driven Development (TDD). See [`CLAUDE.md`](./CLAUDE.m
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/johnburbridge/vagrant-orbstack-provider/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/johnburbridge/vagrant-orbstack-provider/discussions)
+- **Issues**: [GitHub Issues](https://github.com/spiralhouse/vagrant-orbstack-provider/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/spiralhouse/vagrant-orbstack-provider/discussions)
 
 ## License
 


### PR DESCRIPTION
## Summary

Updates README.md for v0.1.0 RubyGems publication with professional presentation suitable for RubyGems.org and new users.

## Changes Made

### 1. Updated Badges Section
- ✅ Added RubyGems version badge linking to rubygems.org
- ✅ Added GitHub Actions CI build status badge
- ✅ Kept codecov and license badges (already correct)

### 2. Updated All GitHub URLs
- ✅ Changed organization from `johnburbridge` to `spiralhouse` throughout
- ✅ Development setup clone URL
- ✅ GitHub Issues and Discussions links

### 3. Simplified Installation Section
- ✅ Primary installation: `vagrant plugin install vagrant-orbstack`
- ✅ Moved local build instructions to Development > Local Testing
- ✅ Clear RubyGems-first approach for users

### 4. Added Table of Contents
- ✅ Comprehensive navigation with all major sections
- ✅ Proper anchor links for easy navigation

### 5. Added Known Limitations Section
- ✅ Box Support limitation documented
- ✅ Synced Folders limitation documented
- ✅ Networking limitation documented
- ✅ Command Execution (`vagrant ssh -c`) limitation with workaround link
- ✅ Provisioners limitation documented
- ✅ macOS-only platform requirement documented
- ✅ Links to CHANGELOG.md and PRD for roadmap

### 6. Enhanced Development Section
- ✅ Added context for local testing workflow
- ✅ Included full test workflow: `vagrant up`, `vagrant ssh`, `vagrant halt`, `vagrant destroy`

## Success Criteria (from SPI-1291)

- ✅ Badges display correctly and link to correct URLs
- ✅ Installation instructions work for users (`vagrant plugin install vagrant-orbstack`)
- ✅ Quick start example can be copy-pasted and works
- ✅ Known limitations clearly stated in dedicated section
- ✅ Professional presentation suitable for RubyGems.org
- ✅ All GitHub URLs point to spiralhouse organization

## Test Plan

- [x] Pre-push hooks passed (RuboCop clean, 617 unit tests passing)
- [x] Documentation-only change (no code changes)
- [x] All sections properly formatted with Markdown
- [x] All internal links work correctly
- [x] Badge URLs point to correct resources

## Related Issues

- Closes [SPI-1291](https://linear.app/spiral-house/issue/SPI-1291/update-readme-for-rubygems-publication)
- Part of [SPI-1129](https://linear.app/spiral-house/issue/SPI-1129) (Documentation & Release Preparation epic)

## Notes

This completes the documentation updates needed for v0.1.0 RubyGems publication. The README now follows conventions from established Vagrant provider plugins and provides a professional first impression for new users on RubyGems.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)