### PR TITLE
docs: update project status to reflect SSH as implemented [SPI-1252]

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,13 @@ These features are planned for future releases. See [CHANGELOG.md](./CHANGELOG.m
   - Idempotent halt/start operations (safe to run multiple times)
   - User-friendly progress messages with machine IDs
 
+- **SSH Connectivity (v0.2.0-dev)**:
+  - SSH access via `vagrant ssh` (SPI-1225)
+  - Provider#ssh_info implementation with OrbStack proxy support
+  - Automatic SSH key management (~/.orbstack/ssh/id_ed25519)
+  - macOS username mapping (OrbStack design)
+  - Known limitation: `vagrant ssh -c` not yet supported (SPI-1240)
+
 - **OrbStack CLI Integration (partial)**:
   - CLI wrapper with command execution and timeout support
   - Machine listing and info retrieval (SPI-1198)
@@ -494,7 +501,6 @@ These features are planned for future releases. See [CHANGELOG.md](./CHANGELOG.m
 
 ### Planned (MVP - v0.2.0+)
 
-- SSH integration for remote access
 - Machine destroy operations
 - OrbStack CLI wrapper completion (delete command)
 - Provisioner support (Shell, Ansible, Chef, Puppet)


### PR DESCRIPTION
## Summary

- Move SSH connectivity from "Planned" to "Implemented" section in README
- Add detailed SSH implementation bullets (proxy support, SSH key management, known limitations)
- Remove "SSH integration for remote access" from Planned section

## Context

SSH functionality was implemented in PR #22 (SPI-1225) but the README's "Project Status" section was not updated. This fix maintains documentation accuracy.

## Test plan

- [x] Verify SSH removed from "Planned" section
- [x] Verify SSH added to "Implemented" section with all details
- [x] Cross-reference with Provider#ssh_info implementation
- [x] Cross-reference with CHANGELOG.md SSH entries
- [x] code-reviewer approval obtained

🤖 Generated with [Claude Code](https://claude.com/claude-code)